### PR TITLE
Problem: Incompatible versions of Django in requirements.txt & dev_re…

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,7 +15,7 @@ decorator==4.0.11         # via ipython, traitlets
 django-debug-toolbar==1.7
 django-jenkins==0.19.0
 django-nose==1.4.4
-django==1.9.8             # via django-debug-toolbar, django-jenkins
+Django==1.10.6            # via django-debug-toolbar, django-jenkins
 emoji==0.3.6
 enum34==1.1.6             # via flake8, traitlets
 factory-boy==2.4.1
@@ -25,7 +25,7 @@ freezegun==0.3.8
 gitdb==0.6.4              # via gitpython
 GitPython==1.0.1
 ipdb==0.10.2
-ipython-genutils==0.1.0   # via traitlets
+ipython-genutils==0.2.0   # via traitlets
 ipython==5.3.0
 json-delta==2.0
 mccabe==0.6.1             # via flake8
@@ -46,7 +46,7 @@ pyflakes==1.5.0           # via flake8
 pygments==2.2.0           # via ipython
 pyparsing==2.2.0          # via packaging
 python-dateutil==2.6.0    # via freezegun
-pyyaml==3.12              # via vcrpy
+PyYAML==3.12              # via vcrpy
 scandir==1.5              # via pathlib2
 simplegeneric==0.8.1      # via ipython
 six==1.10.0               # via freezegun, packaging, pathlib2, pip-tools, prompt-toolkit, python-dateutil, setuptools, traitlets, vcrpy
@@ -56,7 +56,7 @@ traitlets==4.3.2          # via ipython
 vcrpy==1.10.5
 wcwidth==0.1.7            # via prompt-toolkit
 wheel==0.29.0
-wrapt==1.10.8             # via vcrpy
+wrapt==1.10.10            # via vcrpy
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via ipdb, ipython


### PR DESCRIPTION
…quirements.txt

```
Incompatible requirements found: django==1.9.8 (from -r dev_requirements.txt (line 18)) and django==1.10.6 (from -r requirements.txt (line 32))
```

Solution: Upgrade Django in dev_requirements.txt to the same version as in requirements.txt

```
pip-compile --upgrade-package django==1.10.6 dev_requirements.in
```