### PR TITLE
Problem: Redundant variable initialization & mixed indentation

### DIFF
--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -422,12 +422,10 @@ class AccountDriver(BaseAccountDriver):
         return keypair
 
     def shared_images_for(self, image_id):
-        acct_driver = None
-
         shared_with = self.image_manager.shared_images_for(
             image_id=image_id)
 
-	if getattr(settings, "REPLICATION_PROVIDER_LOCATION"):
+        if getattr(settings, "REPLICATION_PROVIDER_LOCATION"):
             from core.models import Provider
             from service.driver import get_account_driver
             provider = Provider.objects.get(location=settings.REPLICATION_PROVIDER_LOCATION)


### PR DESCRIPTION
## Description

Problem: Redundant variable initialization & mixed indentation

Solution: Deleted `acct_driver` which is later set anyway, and changed tabs to spaces.

## Checklist before merging Pull Requests
~~- [ ] New test(s) included to reproduce the bug/verify the feature~~
~~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~~
- [x] Reviewed and approved by at least one other contributor.
