### PR TITLE
Problem: Need unlimited allocation sources

### DIFF
--- a/api/tests/v2/test_allocation_sources.py
+++ b/api/tests/v2/test_allocation_sources.py
@@ -1,4 +1,6 @@
+import decimal
 import itertools
+import uuid
 from unittest import skip
 from django.core import urlresolvers
 from rest_framework.test import APIClient, APIRequestFactory
@@ -8,6 +10,7 @@ from api.tests.factories import (
     UserFactory, AnonymousUserFactory, IdentityFactory, ProviderFactory, AllocationSourceFactory,
     UserAllocationSourceFactory
 )
+from cyverse_allocation.tasks import update_snapshot_cyverse
 from .base import APISanityTestCase
 from api.v2.views import AllocationSourceViewSet as ViewSet
 
@@ -54,6 +57,45 @@ class AllocationSourceTests(APITestCase, APISanityTestCase):
             'compute_allowed': 9000
         }
         self.assertDictContainsSubset(expected_values, allocation_source.__dict__)
+
+    def test_can_create_infinite_allocation_source(self):
+        """Can I create an allocation source with infinite compute_allowed"""
+        client = APIClient()
+        client.force_authenticate(user=self.user_without_sources)
+        payload = {
+            'uuid': str(uuid.uuid4()),
+            'allocation_source_name': 'TG-INF990002',
+            'compute_allowed': -1,
+            'renewal_strategy': 'default'}
+
+        from core.models import EventTable, AllocationSource, AllocationSourceSnapshot
+        creation_event = EventTable(
+            name='allocation_source_created_or_renewed',
+            entity_id=payload['allocation_source_name'],
+            payload=payload)
+
+        creation_event.save()
+
+        allocation_source = AllocationSource.objects.get(name='TG-INF990002')
+        expected_values = {
+            'name': 'TG-INF990002',
+            'compute_allowed': -1
+        }
+        self.assertDictContainsSubset(expected_values, allocation_source.__dict__)
+        assert isinstance(allocation_source, AllocationSource)
+        self.assertEqual(allocation_source.compute_allowed, -1)
+        update_snapshot_cyverse()
+        self.assertEqual(allocation_source.time_remaining(), decimal.Decimal('Infinity'))
+        self.assertEqual(allocation_source.is_over_allocation(), False)
+        allocation_snapshot = allocation_source.snapshot
+        assert isinstance(allocation_snapshot, AllocationSourceSnapshot)
+        self.assertEqual(allocation_snapshot.compute_allowed, -1)
+        self.assertEqual(allocation_snapshot.compute_used, 0)
+        allocation_snapshot.compute_used = 9999999
+        allocation_snapshot.save()
+        self.assertEqual(allocation_source.time_remaining(), decimal.Decimal('Infinity'))
+        self.assertEqual(allocation_source.is_over_allocation(), False)
+
 
     def test_anonymous_user_cant_see_allocation_sources(self):
         request_factory = APIRequestFactory()

--- a/core/models/allocation_source.py
+++ b/core/models/allocation_source.py
@@ -1,3 +1,5 @@
+import decimal
+
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
@@ -36,6 +38,7 @@ class AllocationSource(models.Model):
         user: If passed in *and* allocation source is 'special', calculate remaining time based on user snapshots.
 
         Will return a negative number if 'over allocation', when `compute_used` is larger than `compute_allowed`.
+        Will return Infinity if `compute_allowed` is `-1` (or any negative number)
         :return: decimal.Decimal
         :rtype: decimal.Decimal
         """
@@ -53,6 +56,8 @@ class AllocationSource(models.Model):
         else:
             compute_allowed = self.compute_allowed
             last_snapshot = self.snapshot
+        if compute_allowed < 0:
+            return decimal.Decimal('Infinity')
         compute_used = last_snapshot.compute_used if last_snapshot else 0
         remaining_compute = compute_allowed - compute_used
         return remaining_compute

--- a/cyverse_allocation/tasks.py
+++ b/cyverse_allocation/tasks.py
@@ -67,7 +67,7 @@ def allocation_threshold_check():
         logger.debug("CHECK_THRESHOLD is FALSE -- allocation_threshold_check task finished at %s." % datetime.now())
         return
 
-    for allocation_source in AllocationSource.objects.all():
+    for allocation_source in AllocationSource.objects.filter(compute_allowed__gte=0).all():
         snapshot = allocation_source.snapshot
         percentage_used = (snapshot.compute_used / snapshot.compute_allowed) * 100
         # check if percentage more than threshold

--- a/features/instance.features/edit_instance.feature
+++ b/features/instance.features/edit_instance.feature
@@ -37,8 +37,8 @@ Feature: Launching & editing of an instance
       | user407             | user407           |
     When we update CyVerse snapshots
     Then we should have the following allocation source snapshots
-      | name    | compute_used |
-      | user407 | 0            |
+      | name    | compute_used | compute_allowed |
+      | user407 | 0            | 168             |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user407             | user407           | 0.000        | 0.000     |
@@ -105,8 +105,8 @@ Feature: Launching & editing of an instance
     Given a current time of '2017-02-16T07:02:00Z' with tick = False
     When we update CyVerse snapshots
     Then we should have the following allocation source snapshots
-      | name    | compute_used |
-      | user407 | 0.020        |
+      | name    | compute_used | compute_allowed |
+      | user407 | 0.020        | 168             |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user407             | user407           | 0.020        | 1.000     |
@@ -117,8 +117,8 @@ Feature: Launching & editing of an instance
     Given a current time of '2017-02-16T08:00:00Z' with tick = False
     When we update CyVerse snapshots
     Then we should have the following allocation source snapshots
-      | name    | compute_used |
-      | user407 | 0.980        |
+      | name    | compute_used | compute_allowed |
+      | user407 | 0.980        | 168             |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user407             | user407           | 0.980        | 1.000     |

--- a/features/jetstream.features/enforcing.feature
+++ b/features/jetstream.features/enforcing.feature
@@ -106,8 +106,8 @@ Feature: Enforcing allocation usage on Jetstream
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user208             | TG-BIO150062      | 0.000        | 0.000     |
@@ -141,8 +141,8 @@ Feature: Enforcing allocation usage on Jetstream
     Given a current time of '2017-02-16T07:02:00Z' with tick = False
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user208             | TG-BIO150062      | 0.020        | 1.000     |
@@ -154,8 +154,8 @@ Feature: Enforcing allocation usage on Jetstream
     Given a current time of '2017-02-16T08:00:00Z' with tick = False
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user208             | TG-BIO150062      | 0.980        | 1.000     |

--- a/features/jetstream.features/monitor_jetstream_allocation_sources.feature
+++ b/features/jetstream.features/monitor_jetstream_allocation_sources.feature
@@ -111,9 +111,9 @@ Feature: Monitor Jetstream Allocation Sources
     And we fill user allocation sources from TAS
     And we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-ENG150061 | 781768.010   |
-      | TG-TRA160006 | 87914.060    |
+      | name         | compute_used | compute_allowed |
+      | TG-ENG150061 | 781768.010   | 1000000         |
+      | TG-TRA160006 | 87914.060    | 600000          |
 
 
   Scenario: Correct events, with no duplicates when checking twice

--- a/features/jetstream.features/special_allocation.feature
+++ b/features/jetstream.features/special_allocation.feature
@@ -87,8 +87,8 @@ Feature: Special Allocations
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-ASC160018 | 3000001.100  |
+      | name         | compute_used | compute_allowed |
+      | TG-ASC160018 | 3000001.100  | 5000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user110             | TG-ASC160018      | 0.000        | 0.000     |
@@ -130,8 +130,8 @@ Feature: Special Allocations
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user108             | TG-BIO150062      | 0.000        | 0.000     |
@@ -175,9 +175,9 @@ Feature: Special Allocations
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-TRA160003 | 87914.06     |
-      | TG-ASC160018 | 3000001.100  |
+      | name         | compute_used | compute_allowed |
+      | TG-TRA160003 | 87914.06     | 600000          |
+      | TG-ASC160018 | 3000001.100  | 5000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user111             | TG-TRA160003      | 0.000        | 0.000     |

--- a/features/steps/tas_api_steps.py
+++ b/features/steps/tas_api_steps.py
@@ -164,18 +164,18 @@ def update_snapshots(context):
 def should_have_allocation_sources(context):
     expected_allocation_sources = dict((row.cells[0], Decimal(row.cells[1]),) for row in context.table)
     from core.models import AllocationSource
-    allocation_sources = {item['name']: item['compute_allowed'] for item in
-                          AllocationSource.objects.all().order_by('name').values('name', 'compute_allowed')}
+    allocation_sources = {item.name: item.compute_allowed for item in
+                          AllocationSource.objects.all().order_by('name')}
     context.test.assertDictEqual(expected_allocation_sources, allocation_sources)
 
 
 @then(u'we should have the following allocation source snapshots')
 def should_have_allocation_source_snapshots(context):
-    expected_allocation_source_snapshots = dict((row.cells[0], Decimal(row.cells[1]),) for row in context.table)
+    expected_allocation_source_snapshots = dict(
+        (row.cells[0], [Decimal(row.cells[1]), Decimal(row.cells[2])],) for row in context.table)
     from core.models import AllocationSourceSnapshot
-    allocation_source_snapshots = {item['allocation_source__name']: item['compute_used'] for item in
-                                   AllocationSourceSnapshot.objects.all().values('allocation_source__name',
-                                                                                 'compute_used')}
+    allocation_source_snapshots = {item.allocation_source.name: [item.compute_used, item.compute_allowed] for item in
+                                   AllocationSourceSnapshot.objects.select_related('allocation_source').all()}
     context.test.assertDictEqual(expected_allocation_source_snapshots, allocation_source_snapshots)
 
 


### PR DESCRIPTION
Solution: Interpret a `compute_allowed` of `-1` as unlimited.

Note: Have to handle this case in the UI as well.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
