### PR TITLE
Bump pip-tools to 1.10.1 and fix parsing of pip-compile version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@
   install:
     # setuptools and pip-tools are necessary for ./travis/check_properly_generated_requirements.sh
     - pip install -U pip setuptools
-    - pip install pip-tools==1.11.0
+    - pip install pip-tools==1.11.1
 
   before_script:
     - psql -c "CREATE USER atmosphere_db_user WITH PASSWORD 'atmosphere_db_pass' CREATEDB;" -U postgres

--- a/travis/check_properly_generated_requirements.sh
+++ b/travis/check_properly_generated_requirements.sh
@@ -11,7 +11,7 @@
 # This script properly generates the requirements and performs a diff with the
 # current requirements.
 
-PIP_TOOLS_VERSION=1.11.0
+PIP_TOOLS_VERSION=1.11.1
 
 function main {
 


### PR DESCRIPTION
## Description

Pip-tools had an internal error fixed by this upgrade.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
